### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Staple tracker
 Code for the method described in the paper **Staple: Complementary Learners for Real-Time Tracking**, by Luca Bertinetto, Jack Valmadre, Stuart Golodetz, Ondrej Miksik and Philip Torr (University of Oxford) - appeared at CVPR 2016.
 
-###Contacts
+### Contacts
 For questions about the code or the paper, feel free contact us.
 You can find more info at the project page: http://robots.ox.ac.uk/~luca/staple.html
 
@@ -17,16 +17,16 @@ year = {2016}
 }
 ```
 
-###Prerequisites
+### Prerequisites
  - The code is mostly in MATLAB, except the workhorse of `fhog.m`, which is written in C and comes from Piotr Dollar toolbox http://vision.ucsd.edu/~pdollar/toolbox
  - To use the webcam mode (`runTracker_webcam`), install MATLAB's webcam support from http://mathworks.com/hardware-support/matlab-webcam.html
 
-###Modes
+### Modes
 * `runTracker(sequence, start_frame)` runs the tracker on `sequence` from `start_frame` onwards.
 * `runTracker_webcam` starts an interactive webcam demo.
 * `runTracker_VOT` and `run_Staple` run the tracker within the benchmarks VOT and OTB respectively.
 
-###Format
+### Format
 For `runTracker(sequence, start_frame)`, make sure the directory tree looks like the following:
 
     - staple/
@@ -51,7 +51,7 @@ Each sequence folder should have the following structure
 * `<sequence_name>`_frames.txt contains the interval of frames to track
 * groundtruth.txt contains the per frame annotation. The ground truth bounding box can be expressed as a polygon, i.e. `<x1>,<y1>,<x2>,<y2>,<x3>,<y3>,<x4>,<y4>`, or as an axis-aligned bounding box, i.e.`<top-x>,<top-y>,<width>,<height>`
 
-###F.A.Q.
+### F.A.Q.
 
 > How can I compile `mexResize` ?
 `gradientMex` and `mexResize` have been compiled and tested for Ubuntu and Windows 8 (64 bit). You can easily recompile the sources in case of need. I have compiled mexResize following the instructions in Martin's old code for DSST. You can find it here http://www.cvl.isy.liu.se/research/objrec/visualtracking/scalvistrack/index.html - just open the archive and run compilemex.m or compilemex_win.m


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
